### PR TITLE
chore(Application Setup): Configure express and app setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ]
+}

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: ICDptHdJ51sTCPnxDKYEF6QVIGw8FP5iB

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,37 @@
+{
+  "root": true,
+  "extends": "airbnb-base",
+  "env": {
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+  "rules": {
+    "no-unused-expressions": 0,
+    "linebreak-style": 0,
+    "one-var": 0,
+    "one-var-declaration-per-line": 0,
+    "new-cap": 0,
+    "consistent-return": 0,
+    "no-param-reassign": 0,
+    "comma-dangle": 0,
+    "curly": ["error", "multi-line"],
+    "import/no-unresolved": [2, { "commonjs": true }],
+    "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true, "optionalDependencies": false, "peerDependencies": false }],
+    "import/prefer-default-export": 0,
+    "valid-jsdoc": ["error", {
+      "requireReturn": true,
+      "requireReturnType": true,
+      "requireParamDescription": false,
+      "requireReturnDescription": true
+    }],
+    "require-jsdoc": ["error", {
+        "require": {
+            "FunctionDeclaration": true,
+            "MethodDefinition": true,
+            "ClassDeclaration": true
+        }
+    }]
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### What does this PR do?
+
+### Description of task completed?
+
+### How should this be manually tested?
+
+### Any background context you want to provide?

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+package-lock.json

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+jshint:
+  enabled: false
+eslint:
+  enabled: true
+  config_file: .eslintrc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Mock-Premier-League
 API that serves the latest scores of fixtures of matches in a “Mock Premier League”
+
+[![Reviewed by Hound](http://img.shields.io/badge/Reviewed%20By-Hound-%23a874d1)](https://houndci.com)
+[![Build Status](https://travis-ci.org/tobslob/Mock-Premier-League.svg?branch=master)](https://travis-ci.org/tobslob/Mock-Premier-League.svg?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/tobslob/Mock-Premier-League/badge.svg?branch=master)](https://coveralls.io/github/tobslob/Mock-Premier-League?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1f78f6d74b35d99749f3/maintainability)](https://codeclimate.com/github/tobslob/Mock-Premier-League/maintainability)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "mock-premier-league",
+  "version": "1.0.0",
+  "description": "API that serves the latest scores of fixtures of matches in a “Mock Premier League”",
+  "main": "index.js",
+  "scripts": {
+    "start": "cross-env NODE_ENV=production babel-node src/app.js",
+    "start:dev": "cross-env NODE_ENV=production nodemon --exec babel-node src/app.js",
+    "lint": "./node_modules/.bin/eslint",
+    "lint:fix": "./node_modules/.bin/eslint --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tobslob/Mock-Premier-League.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tobslob/Mock-Premier-League/issues"
+  },
+  "homepage": "https://github.com/tobslob/Mock-Premier-League#readme",
+  "dependencies": {
+    "bcrypt": "^3.0.6",
+    "body-parser": "^1.19.0",
+    "dotenv": "^8.0.0",
+    "express": "^4.17.1",
+    "express-error-handler": "^1.1.0",
+    "joi": "^14.3.1",
+    "jsonwebtoken": "^8.5.1"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.5",
+    "@babel/node": "^7.4.5",
+    "@babel/polyfill": "^7.4.4",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/register": "^7.4.4",
+    "babel-core": "^6.26.3",
+    "coveralls": "^3.0.4",
+    "cross-env": "^5.2.0",
+    "eslint": "^6.0.1",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.18.0",
+    "husky": "^3.0.3",
+    "istanbul": "^0.4.5",
+    "lint-staged": "^9.2.1",
+    "morgan": "^1.9.1",
+    "nodemon": "^1.19.1",
+    "nyc": "^14.1.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "npm run lint:fix",
+      "git add"
+    ]
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,47 @@
+import http from 'http';
+import morgan from 'morgan';
+import express from 'express';
+import bodyparser from 'body-parser';
+
+const app = express();
+
+app.use(morgan('dev'));
+app.use(bodyparser.urlencoded({ extended: true }));
+app.use(bodyparser.json());
+
+// Home page route
+app.get('/', (req, res) => {
+  res.status(200).json({
+    status: 200,
+    data: { message: 'Welcome to Mock Premier League' }
+  });
+});
+
+// handle all error
+app.use((err, req, res, next) => {
+  if (err) {
+    return res.status(500).json({
+      status: 500,
+      error: 'Internal server error'
+    });
+  }
+  return next();
+});
+
+// Handle non exist route with with proper message
+app.use((req, res) => {
+  res.status(404).json({
+    status: 404,
+    error: 'Wrong request. Route does not exist'
+  });
+});
+
+const server = http.createServer(app);
+const port = process.env.PORT || 5500;
+
+server.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`listening to server on 127.0.0.1:${port}`);
+});
+
+module.exports = app;

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "stable"
+notifications:
+  email: false
+services:
+  - postgresql
+cache:
+  directories:
+    - node_modules
+before_script:
+  - npm install
+  - psql -c 'create database travis_ci_test;' -U postgres
+script: 
+  - npm run test
+after_success:
+  - npm run coverage
+  - npm run report-coverage


### PR DESCRIPTION
### What does this PR do?

PR to setup express app, basic files and dependencies

### Description of task completed?

- Configure babel for transpile
- Install dependencies and devDependencies
- Configure eslint
- Add application respective folders
- configure hound-CI
- Add gitignore

### How should this be manually tested?
- CLONE the repo
- run ``` npm install ```
- run ``` npm run start:dev ```

### Any background context you want to provide?
when you run ``` npm run start:dev ``` app should listen to port ``` 5500 ``` and can be access in localhost

[Maintains]