### PR TITLE
feat(Edit-Team): Admin can edit team

### DIFF
--- a/src/controllers/TeamController.js
+++ b/src/controllers/TeamController.js
@@ -91,6 +91,59 @@ class TeamController {
         });
     }
   }
+
+  /**
+   *  admin can edit a team method
+   * @param {object} req - response object
+   * @param {object} res - response object
+   * @param {number} status - http status code
+   * @param {string} statusMessage - http status message
+   * @param {object} data - response data
+   *
+   * @returns {object} returns response
+   *
+   * @example
+   *
+   */
+  static async editTeam(req, res) {
+    const { teamName, teamMembers, description } = req.body;
+    try {
+      const team = await TeamModel.findByIdAndUpdate(
+        { _id: req.params.teamId },
+        {
+          $set: {
+            teamName,
+            teamMembers,
+            description,
+            updatedAt: Date.now()
+          }
+        },
+        { useFindAndModify: false }
+      )
+        .exec();
+      if (!req.user.isAdmin) {
+        return response(res, 403, 'error', {
+          message: messages.unAuthorizedRoute
+        });
+      }
+      if (!team) {
+        return response(res, 404, 'error', {
+          message: messages.notfound
+        });
+      }
+      return response(res, 200, 'success', {
+        message: messages.updateMessage
+      });
+    } catch (error) {
+      error.name === 'CastError'
+        ? response(res, 400, 'error', {
+          message: messages.castError
+        })
+        : response(res, 400, 'error', {
+          message: messages.error
+        });
+    }
+  }
 }
 
 export default TeamController;

--- a/src/routes/teamRoute.js
+++ b/src/routes/teamRoute.js
@@ -12,4 +12,7 @@ router.post('/team', Authentication.verifyToken, validate(addTeamSchema), TeamCo
 // remove a team route
 router.delete('/team/:teamId', Authentication.verifyToken, TeamController.removeTeam);
 
+// edit a team route
+router.put('/team/:teamId', Authentication.verifyToken, validate(addTeamSchema), TeamController.editTeam);
+
 export default router;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -16,7 +16,8 @@ const messages = {
   unAuthorizedRoute: 'You do not have permission to this route',
   deleteMessage: 'Sucessfully deleted',
   castError: 'Invalid ID',
-  duplicateName: 'team already exist',
+  duplicateName: 'Team already exist',
+  updateMessage: 'Successfully updated'
 };
 
 export default messages;


### PR DESCRIPTION
### What does this PR do?
PR to enable admin to edit team
### Description of task completed?
- Create a edit controller
- Create a edit route
- Update utils messages
### How should this be manually tested?
- CLONE repo
- Run npm install
- Login as an admin to test PUT /api/v1/team/:teamId
### Any background context you want to provide?
[Finishes]