### PR TITLE
feat(Add-Fixture): Admin can add match fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "express-error-handler": "^1.1.0",
     "jsonwebtoken": "^8.5.1",
+    "moment": "^2.24.0",
     "mongodb": "^3.3.2",
     "mongoose": "^5.7.1",
     "mongoose-paginate": "^5.0.3",

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import messages from './utils/messages';
 import connect from './database/db';
 import user from './routes/userRoute';
 import team from './routes/teamRoute';
+import fixture from './routes/fixtureRoute';
 
 const app = express();
 
@@ -23,6 +24,7 @@ app.use(trimmer);
 // api endpoints
 app.use('/api/v1/user', user);
 app.use('/api/v1', team);
+app.use('/api/v1', fixture);
 
 // Home page route
 app.get('/', (req, res) => {
@@ -52,7 +54,7 @@ app.use((req, res) => {
 });
 
 const server = http.createServer(app);
-const port = process.env.PORT || 5500;
+const port = process.env.PORT || 5000;
 const listen = messages.listenToServer;
 
 if (process.env.NODE_ENV !== 'test') {

--- a/src/controllers/FixtureController.js
+++ b/src/controllers/FixtureController.js
@@ -1,0 +1,65 @@
+import mongoose from 'mongoose';
+import FixtureModel from '../models/fixtureModel';
+import response from '../utils/response';
+import messages from '../utils/messages';
+import compareTwoArrays from '../helper.js/compareTwoArrays';
+
+/** *
+ * @exports {class} FixtureController
+ */
+class FixtureController {
+  /**
+   *  admin can add fixture
+   * @param {object} req - response object
+   * @param {object} res - response object
+   * @param {number} status - http status code
+   * @param {string} statusMessage - http status message
+   * @param {object} data - response data
+   *
+   * @returns {object} returns response
+   *
+   * @example
+   *
+   */
+  static async addFixture(req, res) {
+    const { teamA, teamB, matchInfo } = req.body;
+    try {
+      if (!req.user.isAdmin) {
+        return response(res, 404, 'error', {
+          message: messages.unAuthorizedRoute
+        });
+      }
+      const fixture = new FixtureModel({
+        _id: new mongoose.Types.ObjectId(),
+        teamA,
+        teamB,
+        matchInfo
+      });
+
+      const compare = await compareTwoArrays(teamA, teamB);
+      if (compare) {
+        return response(res, 409, 'error', {
+          message: messages.sameTeam
+        });
+      }
+      const result = await FixtureModel.find({ teamA, teamB, matchInfo });
+      if (result.length >= 1) {
+        return response(res, 409, 'error', {
+          message: messages.existingFixture
+        });
+      }
+      const createfixture = await fixture.save();
+      if (createfixture) {
+        return response(res, 201, 'success', {
+          createfixture
+        });
+      }
+    } catch (error) {
+      return response(res, 400, 'error', {
+        message: messages.error
+      });
+    }
+  }
+}
+
+export default FixtureController;

--- a/src/controllers/TeamController.js
+++ b/src/controllers/TeamController.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import moment from 'moment';
 import TeamModel from '../models/teamModel';
 import response from '../utils/response';
 import messages from '../utils/messages';
@@ -115,7 +116,7 @@ class TeamController {
             teamName,
             teamMembers,
             description,
-            updatedAt: Date.now()
+            updatedAt: moment(Date.now()).format('LLLL')
           }
         },
         { useFindAndModify: false }
@@ -162,7 +163,7 @@ class TeamController {
     const { teamId } = req.params;
     try {
       const team = await TeamModel.findById({ _id: teamId })
-        .select('_id teamName teamMembers description')
+        .select('_id teamName teamMembers description createdAt updatedAt')
         .exec();
       if (!team) {
         return response(res, 404, 'error', {
@@ -199,7 +200,7 @@ class TeamController {
   static async viewAllTeam(req, res) {
     try {
       const teams = await TeamModel.find()
-        .select('_id teamName teamMembers description')
+        .select('_id teamName teamMembers description createdAt updatedAt')
         .exec();
       return response(res, 200, 'success', {
         teams,

--- a/src/helper.js/compareTwoArrays.js
+++ b/src/helper.js/compareTwoArrays.js
@@ -1,0 +1,20 @@
+/**
+ * helper method to compare two arrays
+ * @param {*} x
+ * @param {*} y
+ * @returns {true} objectsAreSame
+ */
+const compareTwoArrays = (x, y) => {
+  let arrayAreSame = false;
+  for (let i = 0, len = x.length; i < len; i += 1) {
+    for (let j = 0, len2 = y.length; j < len2; j += 1) {
+      if (x[i].name === y[j].name) {
+        arrayAreSame = true;
+        break;
+      }
+    }
+    return arrayAreSame;
+  }
+};
+
+export default compareTwoArrays;

--- a/src/middlewares/checkIfTeamIsPresentInDatabase.js
+++ b/src/middlewares/checkIfTeamIsPresentInDatabase.js
@@ -1,0 +1,40 @@
+import TeamModel from '../models/teamModel';
+import messages from '../utils/messages';
+import response from '../utils/response';
+
+/**
+   * Middleware to check if teams are
+   * present in the database
+   * @param {object} req - response object
+   * @param {object} res - response object
+   * @param {object} next - response object
+   * @param {number} status - http status code
+   * @param {string} statusMessage - http status message
+   * @param {object} data - response data
+   *
+   * @returns {object} returns response
+   *
+   * @example
+   *
+   */
+const checkIfTeamIsPresentInDatabase = async (req, res, next) => {
+  const teamA = req.body.teamA[0].name;
+  const teamB = req.body.teamB[0].name;
+
+  try {
+    const team1 = await TeamModel.find({ teamName: teamA }).exec();
+    const team2 = await TeamModel.find({ teamName: teamB }).exec();
+    if (team1.length <= 0 || team2.length <= 0) {
+      return response(res, 404, 'error', {
+        message: messages.teamNotFound
+      });
+    }
+    return next();
+  } catch (error) {
+    return response(res, 400, 'error', {
+      message: messages.error
+    });
+  }
+};
+
+export default checkIfTeamIsPresentInDatabase;

--- a/src/models/fixtureModel.js
+++ b/src/models/fixtureModel.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose';
+import moment from 'moment';
+
+const team = {
+  ref: 'TeamModel',
+  type: Array,
+  name: {
+    type: String,
+    enum: ['AFC Bournemouth', 'Arsenal', 'Aston Villa', 'Brighton & Hove Albion', 'Burnley', 'Chelsea',
+      'Crystal Palace', 'Everton', 'Leicester City', 'Liverpool', 'Manchester City', 'Manchester United',
+      'Newcastle United', ' Norwich City', 'Sheffield United', 'Southampton', 'Tottenham Hotspur', 'Watford',
+      'West Ham United', 'Wolverhampton Wanderers']
+  },
+  score: { type: Number, default: 0 }
+};
+
+const fixtureSchema = mongoose.Schema({
+  _id: mongoose.Schema.Types.ObjectId,
+  teamA: team,
+  teamB: team,
+  status: { type: String, default: 'pending' },
+  matchInfo: {
+    type: Array,
+    date: Date,
+    stadium: {
+      type: String,
+      enum: ['Vitality Stadium', 'The Amex', 'Turf Moor', 'Cardiff City Stadium',
+        "John Smith's Stadium", 'King Power Stadium', 'Goodison Park', 'Anfield',
+        'Emirates Stadium', 'Stamford Bridge', 'Selhurst Park', 'Craven Cottage',
+        'Wembley Stadium', 'London Stadium', 'Etihad Stadium', 'Old Trafford',
+        'St James Park', "St Mary's Stadium", 'Vicarage Road', 'Molineux Stadium']
+    }
+  },
+  createdAt: { type: Date, default: moment(new Date()).LLLL },
+  updatedAt: { type: Date, default: moment(new Date()).LLLL }
+});
+
+export default mongoose.model('FixtureModel', fixtureSchema);

--- a/src/models/teamModel.js
+++ b/src/models/teamModel.js
@@ -1,24 +1,31 @@
 import mongoose from 'mongoose';
 import uniqueValidator from 'mongoose-unique-validator';
+import moment from 'moment';
 
 const teamSchema = mongoose.Schema({
   _id: mongoose.Schema.Types.ObjectId,
-  teamName: { type: String, unique: true },
+  teamName: {
+    type: String,
+    unique: true,
+    enum: ['AFC Bournemouth', 'Arsenal', 'Aston Villa', 'Brighton & Hove Albion', 'Burnley', 'Chelsea',
+      'Crystal Palace', 'Everton', 'Leicester City', 'Liverpool', 'Manchester City', 'Manchester United',
+      'Newcastle United', ' Norwich City', 'Sheffield United', 'Southampton', 'Tottenham Hotspur', 'Watford',
+      'West Ham United', 'Wolverhampton Wanderers']
+  },
   teamMembers: {
     name: {
       type: String, lowercase: true, required: true
     },
     role: {
       type: String,
-      enum: ['goal keeper', 'central back', 'central midfield', 'central forward', 'left wing',
-        'attacking midfield', 'central forward', 'left midfielder', 'striker', 'defending', 'right midfielder'],
+      enum: ['Goal Keeper', 'Central Back', 'Central Midfield', 'Central Forward', 'Left Wing', 'Attacking Midfield', 'Central Forward', 'Left Midfielder', 'Striker', 'Defending', 'Right Midfielder'],
       required: true
     },
     type: Array
   },
   description: String,
-  createdAt: { type: Date, default: Date.now() },
-  updatedAt: { type: Date, default: Date.now() }
+  createdAt: { type: Date, default: moment(Date.now()).format('LLLL') },
+  updatedAt: { type: Date, default: moment(Date.now()).format('LLLL') },
 });
 
 teamSchema.plugin(uniqueValidator);

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import moment from 'moment';
 import mongoosePaginate from 'mongoose-paginate';
 import uniqueValidator from 'mongoose-unique-validator';
 
@@ -9,7 +10,8 @@ const userSchema = mongoose.Schema({
   firstName: String,
   lastName: String,
   isAdmin: { type: Boolean, default: false },
-  createdAt: { type: Date, default: Date.now() }
+  createdAt: { type: Date, default: moment(Date.now()).format('LLLL') },
+  updatedAt: { type: Date, default: moment(Date.now()).format('LLLL') },
 });
 
 userSchema.plugin(uniqueValidator);

--- a/src/routes/fixtureRoute.js
+++ b/src/routes/fixtureRoute.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import validate from '../middlewares/validator';
+import FixtureController from '../controllers/FixtureController';
+import Authentication from '../middlewares/Authentication';
+import addFixtureSchema from '../validation/fixtureSchema';
+import checkIfTeamIsPresentInDatabase from '../middlewares/checkIfTeamIsPresentInDatabase';
+
+const router = express.Router();
+
+// create a fixture route
+router.post('/fixture', Authentication.verifyToken, validate(addFixtureSchema), checkIfTeamIsPresentInDatabase, FixtureController.addFixture);
+
+export default router;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -17,7 +17,10 @@ const messages = {
   deleteMessage: 'Sucessfully deleted',
   castError: 'Invalid ID',
   duplicateName: 'Team already exist',
-  updateMessage: 'Successfully updated'
+  updateMessage: 'Successfully updated',
+  existingFixture: 'Same fixture exist',
+  sameTeam: "teamA and teamB can't be the same",
+  teamNotFound: 'one of the team is not available at the moment'
 };
 
 export default messages;

--- a/src/validation/fixtureSchema.js
+++ b/src/validation/fixtureSchema.js
@@ -1,0 +1,24 @@
+import Joi from '@hapi/joi';
+import JoiValidator from './JoiValidator';
+import { name } from './teamSchema';
+
+const validTeam = JoiValidator.validateArray().items({
+  name,
+  score: JoiValidator.validateNumber().min(0).required()
+}).required();
+
+const addFixtureSchema = Joi.object({
+  teamA: validTeam,
+  teamB: validTeam.unique(),
+  status: JoiValidator.validateString().valid('completed', 'ongoing').default('pending'),
+  matchInfo: JoiValidator.validateArray()
+    .items({
+      date: JoiValidator.validateDate().min(Date.now()),
+      stadium: JoiValidator.validateString().valid(
+        'Vitality Stadium', 'The Amex', 'Turf Moor', 'Cardiff City Stadium', "John Smith's Stadium", 'King Power Stadium', 'Goodison Park', 'Anfield', 'Emirates Stadium', 'Stamford Bridge', 'Selhurst Park', 'Craven Cottage',
+        'Wembley Stadium', 'London Stadium', 'Etihad Stadium', 'Old Trafford', 'St James Park', "St Mary's Stadium", 'Vicarage Road', 'Molineux Stadium'
+      )
+    }).required()
+});
+
+export default addFixtureSchema;

--- a/src/validation/teamSchema.js
+++ b/src/validation/teamSchema.js
@@ -1,15 +1,20 @@
 import Joi from '@hapi/joi';
 import JoiValidator from './JoiValidator';
 
+const name = JoiValidator.validateString().valid(
+  'AFC Bournemouth', 'Arsenal', 'Aston Villa', 'Brighton & Hove Albion', 'Burnley', 'Chelsea', 'Crystal Palace', 'Everton', 'Leicester City', 'Liverpool', 'Manchester City', 'Manchester United',
+  'Newcastle United', ' Norwich City', 'Sheffield United', 'Southampton', 'Tottenham Hotspur', 'Watford', 'West Ham United', 'Wolverhampton Wanderers'
+).required();
+
 const addTeamSchema = Joi.object({
-  teamName: JoiValidator.validateString().required(),
+  teamName: name,
   teamMembers: JoiValidator.validateArray()
     .items({
       name: JoiValidator.validateString(),
       role: JoiValidator.validateString()
-        .valid('goal keeper', 'central back', 'central midfield', 'central forward', 'left wing', 'attacking midfield', 'central forward', 'left midfielder', 'striker', 'defending', 'right midfielder')
+        .valid('Goal Keeper', 'Central Back', 'Central Midfield', 'Central Forward', 'Left Wing', 'Attacking Midfield', 'Central Forward', 'Left Midfielder', 'Striker', 'Defending', 'Right Midfielder')
     }).required(),
   description: JoiValidator.validateString()
 });
 
-export default addTeamSchema;
+export { addTeamSchema, name };


### PR DESCRIPTION
### What does this PR do?
PR to enable admin to add fixture to the app
### Description of task completed?
- create fixture controller
- create fixture route
- create middleware to search if team exist
- create fixture validation schema
- create help function to valid the two teams
  if they are not the same
- update validation schema and models
- update messages in utils
### How should this be manually tested?
- CLONE repo
- Run ` npm install `
- Login as an admin to test POST /api/v1/fixture
### Any background context you want to provide?
[Finishes]