### PR TITLE
feat(View-Fixture): Admin can view fixture

### DIFF
--- a/src/controllers/FixtureController.js
+++ b/src/controllers/FixtureController.js
@@ -122,6 +122,11 @@ class FixtureController {
       const {
         teamA, teamB, matchInfo, status
       } = body;
+      if (!req.user.isAdmin) {
+        return response(res, 400, 'error', {
+          message: messages.unAuthorizedRoute
+        });
+      }
       const { fixtureId } = params;
       const fixture = await FixtureModel.findByIdAndUpdate(
         { _id: fixtureId },
@@ -137,11 +142,6 @@ class FixtureController {
         { useFindAndModify: false }
       )
         .exec();
-      if (!req.user.isAdmin) {
-        return response(res, 400, 'error', {
-          message: messages.unAuthorizedRoute
-        });
-      }
       if (!fixture) {
         return response(res, 404, 'error', {
           message: messages.notfound
@@ -152,6 +152,80 @@ class FixtureController {
       });
     } catch (error) {
       return response(res, 400, 'error', {
+        message: messages.error
+      });
+    }
+  }
+
+  /**
+       *  admin can view a fixture method
+       * @param {object} req - response object
+       * @param {object} res - response object
+       * @param {number} status - http status code
+       * @param {string} statusMessage - http status message
+       * @param {object} data - response data
+       *
+       * @returns {object} returns response
+       *
+       * @example
+       *
+       */
+  static async viewAFixture(req, res) {
+    const { fixtureId } = req.params;
+    try {
+      if (!req.user.isAdmin) {
+        return response(res, 400, 'error', {
+          message: messages.unAuthorizedRoute
+        });
+      }
+      const fixture = await FixtureModel.findById({ _id: fixtureId })
+        .exec();
+      if (!fixture) {
+        return response(res, 404, 'error', {
+          message: messages.notfound
+        });
+      }
+      return response(res, 200, 'success', {
+        fixture
+      });
+    } catch (error) {
+      error.name === 'CastError'
+        ? response(res, 400, 'error', {
+          message: messages.castError
+        })
+        : response(res, 400, 'error', {
+          message: messages.error
+        });
+    }
+  }
+
+  /**
+           *  Admin can view all fixture method
+           * @param {object} req - response object
+           * @param {object} res - response object
+           * @param {number} status - http status code
+           * @param {string} statusMessage - http status message
+           * @param {object} data - response data
+           *
+           * @returns {object} returns response
+           *
+           * @example
+           *
+           */
+  static async viewAllFixture(req, res) {
+    try {
+      if (!req.user.isAdmin) {
+        return response(res, 400, 'error', {
+          message: messages.unAuthorizedRoute
+        });
+      }
+      const fixture = await FixtureModel.find().exec();
+      return response(res, 200, 'success', {
+        fixture,
+        count: fixture.length
+      });
+    } catch (error) {
+      response(res, 400, 'error', {
         message: messages.error
       });
     }

--- a/src/routes/fixtureRoute.js
+++ b/src/routes/fixtureRoute.js
@@ -16,4 +16,10 @@ router.delete('/fixture/:fixtureId', Authentication.verifyToken, FixtureControll
 // edit a fixture route
 router.put('/fixture/:fixtureId', Authentication.verifyToken, validate(addFixtureSchema), checkIfTeamIsPresentInDatabase, FixtureController.editFixture);
 
+// view a fixture route
+router.get('/fixture/:fixtureId', Authentication.verifyToken, FixtureController.viewAFixture);
+
+// view all fixture route
+router.get('/fixtures', Authentication.verifyToken, FixtureController.viewAllFixture);
+
 export default router;


### PR DESCRIPTION
### What does this PR do?
PR to enable admin view fixtures
### Description of task completed?
- Create a controller to view single and fixtures
- Create a route to view single and all fixtures
### How should this be manually tested?
- CLONE repo
- Run ` npm install `
- Login as an admin to test ` GET /api/v1/fixture/:fixtureId ` and ` GET /api/v1/fixture ` on postman
### Any background context you want to provide?
[Finishes]