### PR TITLE
feat(Completed and Pending Fixture): User can view completed or pending fixtures

### DIFF
--- a/src/controllers/FixtureController.js
+++ b/src/controllers/FixtureController.js
@@ -230,6 +230,62 @@ class FixtureController {
       });
     }
   }
+
+  /**
+       *  User can view all completed fixture method
+       * @param {object} req - response object
+       * @param {object} res - response object
+       * @param {number} status - http status code
+       * @param {string} statusMessage - http status message
+       * @param {object} data - response data
+       *
+       * @returns {object} returns response
+       *
+       * @example
+       *
+       */
+  static async viewCompletedFixture(req, res) {
+    try {
+      const fixture = await FixtureModel.find({ status: 'completed' })
+        .exec();
+      return response(res, 200, 'success', {
+        fixture,
+        count: fixture.length
+      });
+    } catch (error) {
+      return response(res, 400, 'error', {
+        message: messages.error
+      });
+    }
+  }
+
+  /**
+       *  User can view all pending fixture method
+       * @param {object} req - response object
+       * @param {object} res - response object
+       * @param {number} status - http status code
+       * @param {string} statusMessage - http status message
+       * @param {object} data - response data
+       *
+       * @returns {object} returns response
+       *
+       * @example
+       *
+       */
+  static async viewPendingFixture(req, res) {
+    try {
+      const fixture = await FixtureModel.find({ status: 'pending' })
+        .exec();
+      return response(res, 200, 'success', {
+        fixture,
+        count: fixture.length
+      });
+    } catch (error) {
+      return response(res, 400, 'error', {
+        message: messages.error
+      });
+    }
+  }
 }
 
 export default FixtureController;

--- a/src/routes/fixtureRoute.js
+++ b/src/routes/fixtureRoute.js
@@ -22,4 +22,10 @@ router.get('/fixture/:fixtureId', Authentication.verifyToken, FixtureController.
 // view all fixture route
 router.get('/fixtures', Authentication.verifyToken, FixtureController.viewAllFixture);
 
+// view completed fixtures route
+router.get('/fixtures/completed', Authentication.verifyToken, FixtureController.viewCompletedFixture);
+
+// view all pending fixture route
+router.get('/fixtures/pending', Authentication.verifyToken, FixtureController.viewPendingFixture);
+
 export default router;


### PR DESCRIPTION
### What does this PR do?
PR to enable users to view completed or pending fixtures
### Description of task completed?
- Create completed and pending controllers
- Create routes for completed and pending fixture
### How should this be manually tested?
- CLONE repo
- Run ` npm install `
- Login as a user to test GET /api/v1/fixture/completed and GET /api/v1/fixture/pending on postman
### Any background context you want to provide?
[Finishes]